### PR TITLE
Add package.json#exports and fix peer dependencies

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "4.0.0-alpha.1"
+  "version": "4.0.0-alpha.2"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "3.2.1-alpha.0"
+  "version": "4.0.0-alpha.0"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "4.0.0-alpha.0"
+  "version": "4.0.0-alpha.1"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "3.2.0"
+  "version": "3.2.1-alpha.0"
 }

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "publish:major": "lerna publish major --force-publish '*' && yarn postpublish"
   },
   "devDependencies": {
-    "@gltf-transform/core": "^3.6.0",
-    "@gltf-transform/extensions": "^3.6.0",
-    "@gltf-transform/functions": "^3.6.0",
+    "@gltf-transform/core": "^3.7.0",
+    "@gltf-transform/extensions": "^3.7.0",
+    "@gltf-transform/functions": "^3.7.0",
     "@rollup/plugin-node-resolve": "^15.2.1",
     "lerna": "^7.3.0",
     "rimraf": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,11 @@
     "test": "node test/test.js",
     "version": "yarn build",
     "postpublish": "git push && git push --tags",
+    "publish:prepatch": "lerna publish prepatch --dist-tag next --force-publish '*' && yarn postpublish",
     "publish:patch": "lerna publish patch --force-publish '*' && yarn postpublish",
+    "publish:preminor": "lerna publish preminor --dist-tag next --force-publish '*' && yarn postpublish",
     "publish:minor": "lerna publish minor --force-publish '*' && yarn postpublish",
+    "publish:premajor": "lerna publish premajor --dist-tag next --force-publish '*' && yarn postpublish",
     "publish:major": "lerna publish major --force-publish '*' && yarn postpublish"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,11 +11,9 @@
     "test": "node test/test.js",
     "version": "yarn build",
     "postpublish": "git push && git push --tags",
-    "publish:prepatch": "lerna publish prepatch --dist-tag next --force-publish '*' && yarn postpublish",
+    "publish:prerelease": "lerna publish prerelease --dist-tag next --force-publish '*' && yarn postpublish",
     "publish:patch": "lerna publish patch --force-publish '*' && yarn postpublish",
-    "publish:preminor": "lerna publish preminor --dist-tag next --force-publish '*' && yarn postpublish",
     "publish:minor": "lerna publish minor --force-publish '*' && yarn postpublish",
-    "publish:premajor": "lerna publish premajor --dist-tag next --force-publish '*' && yarn postpublish",
     "publish:major": "lerna publish major --force-publish '*' && yarn postpublish"
   },
   "devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,7 +4,10 @@
   "version": "4.0.0-alpha.1",
   "type": "module",
   "main": "./dist/core.cjs",
-  "exports": "./dist/core.js",
+  "exports": {
+    "require": "./dist/core.cjs",
+    "default": "./dist/core.js"
+  },
   "author": "NYTimes R&D",
   "license": "Apache-2.0",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,8 +18,8 @@
     "meshoptimizer": "^0.19.0"
   },
   "peerDependencies": {
-    "@gltf-transform/core": "2.x",
-    "@gltf-transform/extensions": "2.x",
-    "@gltf-transform/functions": "2.x"
+    "@gltf-transform/core": "3.x",
+    "@gltf-transform/extensions": "3.x",
+    "@gltf-transform/functions": "3.x"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,10 +1,10 @@
 {
   "private": true,
   "name": "@nyt/bundler-plugin-gltf",
-  "version": "3.2.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "type": "module",
-  "main": "dist/core.cjs",
-  "module": "dist/core.js",
+  "main": "./dist/core.cjs",
+  "exports": "./dist/core.js",
   "author": "NYTimes R&D",
   "license": "Apache-2.0",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@nyt/bundler-plugin-gltf",
-  "version": "3.2.0",
+  "version": "3.2.1-alpha.0",
   "type": "module",
   "main": "dist/core.cjs",
   "module": "dist/core.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@nyt/bundler-plugin-gltf",
-  "version": "4.0.0-alpha.0",
+  "version": "4.0.0-alpha.1",
   "type": "module",
   "main": "./dist/core.cjs",
   "exports": "./dist/core.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@nyt/bundler-plugin-gltf",
-  "version": "4.0.0-alpha.1",
+  "version": "4.0.0-alpha.2",
   "type": "module",
   "main": "./dist/core.cjs",
   "exports": {

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -6,7 +6,7 @@ export default {
   input: "./core.js",
   output: [
     { file: pkg.main, format: "cjs", exports: "default" },
-    { file: pkg.exports, format: "es", exports: "default" },
+    { file: pkg.exports.default, format: "es", exports: "default" },
   ],
   external: [
     "path",

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -6,7 +6,7 @@ export default {
   input: "./core.js",
   output: [
     { file: pkg.main, format: "cjs", exports: "default" },
-    { file: pkg.module, format: "es", exports: "default" },
+    { file: pkg.exports, format: "es", exports: "default" },
   ],
   external: [
     "path",

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -5,7 +5,10 @@
   "version": "4.0.0-alpha.1",
   "type": "module",
   "main": "./dist/rollup.cjs",
-  "exports": "./dist/rollup.js",
+  "exports": {
+    "require": "./dist/rollup.cjs",
+    "default": "./dist/rollup.js"
+  },
   "author": "NYTimes R&D",
   "license": "Apache-2.0",
   "files": [

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -2,7 +2,7 @@
   "name": "rollup-plugin-gltf",
   "description": "Rollup plugin for optimizing glTF 3D models",
   "repository": "github:nytimes/rd-bundler-3d-plugins",
-  "version": "3.2.0",
+  "version": "3.2.1-alpha.0",
   "type": "module",
   "main": "dist/rollup.cjs",
   "module": "dist/rollup.js",

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -2,7 +2,7 @@
   "name": "rollup-plugin-gltf",
   "description": "Rollup plugin for optimizing glTF 3D models",
   "repository": "github:nytimes/rd-bundler-3d-plugins",
-  "version": "4.0.0-alpha.1",
+  "version": "4.0.0-alpha.2",
   "type": "module",
   "main": "./dist/rollup.cjs",
   "exports": {

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -26,5 +26,8 @@
     "@gltf-transform/core": "3.x",
     "@gltf-transform/extensions": "3.x",
     "@gltf-transform/functions": "3.x"
+  },
+  "devDependencies": {
+    "@nyt/bundler-plugin-gltf": "workspace:^"
   }
 }

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -2,7 +2,7 @@
   "name": "rollup-plugin-gltf",
   "description": "Rollup plugin for optimizing glTF 3D models",
   "repository": "github:nytimes/rd-bundler-3d-plugins",
-  "version": "4.0.0-alpha.0",
+  "version": "4.0.0-alpha.1",
   "type": "module",
   "main": "./dist/rollup.cjs",
   "exports": "./dist/rollup.js",

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -2,10 +2,10 @@
   "name": "rollup-plugin-gltf",
   "description": "Rollup plugin for optimizing glTF 3D models",
   "repository": "github:nytimes/rd-bundler-3d-plugins",
-  "version": "3.2.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "type": "module",
-  "main": "dist/rollup.cjs",
-  "module": "dist/rollup.js",
+  "main": "./dist/rollup.cjs",
+  "exports": "./dist/rollup.js",
   "author": "NYTimes R&D",
   "license": "Apache-2.0",
   "files": [

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -23,8 +23,8 @@
     "meshoptimizer": "^0.19.0"
   },
   "peerDependencies": {
-    "@gltf-transform/core": "2.x",
-    "@gltf-transform/extensions": "2.x",
-    "@gltf-transform/functions": "2.x"
+    "@gltf-transform/core": "3.x",
+    "@gltf-transform/extensions": "3.x",
+    "@gltf-transform/functions": "3.x"
   }
 }

--- a/packages/rollup/rollup.config.js
+++ b/packages/rollup/rollup.config.js
@@ -7,7 +7,7 @@ export default {
   input: "./rollup.js",
   output: [
     { file: pkg.main, format: "cjs", exports: "default" },
-    { file: pkg.exports, format: "es", exports: "default" },
+    { file: pkg.exports.default, format: "es", exports: "default" },
   ],
   plugins: [resolve()],
   external: [

--- a/packages/rollup/rollup.config.js
+++ b/packages/rollup/rollup.config.js
@@ -7,7 +7,7 @@ export default {
   input: "./rollup.js",
   output: [
     { file: pkg.main, format: "cjs", exports: "default" },
-    { file: pkg.module, format: "es", exports: "default" },
+    { file: pkg.exports, format: "es", exports: "default" },
   ],
   plugins: [resolve()],
   external: [

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -2,7 +2,7 @@
   "name": "vite-plugin-gltf",
   "description": "Vite plugin for optimizing glTF 3D models",
   "repository": "github:nytimes/rd-bundler-3d-plugins",
-  "version": "3.2.0",
+  "version": "3.2.1-alpha.0",
   "type": "module",
   "main": "dist/vite.cjs",
   "module": "dist/vite.js",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -2,7 +2,7 @@
   "name": "vite-plugin-gltf",
   "description": "Vite plugin for optimizing glTF 3D models",
   "repository": "github:nytimes/rd-bundler-3d-plugins",
-  "version": "4.0.0-alpha.1",
+  "version": "4.0.0-alpha.2",
   "type": "module",
   "main": "./dist/vite.cjs",
   "exports": {

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -26,5 +26,8 @@
     "@gltf-transform/core": "3.x",
     "@gltf-transform/extensions": "3.x",
     "@gltf-transform/functions": "3.x"
+  },
+  "devDependencies": {
+    "@nyt/bundler-plugin-gltf": "workspace:^"
   }
 }

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -2,10 +2,10 @@
   "name": "vite-plugin-gltf",
   "description": "Vite plugin for optimizing glTF 3D models",
   "repository": "github:nytimes/rd-bundler-3d-plugins",
-  "version": "3.2.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "type": "module",
-  "main": "dist/vite.cjs",
-  "module": "dist/vite.js",
+  "main": "./dist/vite.cjs",
+  "exports": "./dist/vite.js",
   "author": "NYTimes R&D",
   "license": "Apache-2.0",
   "files": [

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -5,7 +5,10 @@
   "version": "4.0.0-alpha.1",
   "type": "module",
   "main": "./dist/vite.cjs",
-  "exports": "./dist/vite.js",
+  "exports": {
+    "require": "./dist/vite.cjs",
+    "default": "./dist/vite.js"
+  },
   "author": "NYTimes R&D",
   "license": "Apache-2.0",
   "files": [

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -23,8 +23,8 @@
     "meshoptimizer": "^0.19.0"
   },
   "peerDependencies": {
-    "@gltf-transform/core": "2.x",
-    "@gltf-transform/extensions": "2.x",
-    "@gltf-transform/functions": "2.x"
+    "@gltf-transform/core": "3.x",
+    "@gltf-transform/extensions": "3.x",
+    "@gltf-transform/functions": "3.x"
   }
 }

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -2,7 +2,7 @@
   "name": "vite-plugin-gltf",
   "description": "Vite plugin for optimizing glTF 3D models",
   "repository": "github:nytimes/rd-bundler-3d-plugins",
-  "version": "4.0.0-alpha.0",
+  "version": "4.0.0-alpha.1",
   "type": "module",
   "main": "./dist/vite.cjs",
   "exports": "./dist/vite.js",

--- a/packages/vite/rollup.config.js
+++ b/packages/vite/rollup.config.js
@@ -7,7 +7,7 @@ export default {
   input: "./vite.js",
   output: [
     { file: pkg.main, format: "cjs", exports: "default" },
-    { file: pkg.module, format: "es", exports: "default" },
+    { file: pkg.exports, format: "es", exports: "default" },
   ],
   plugins: [resolve()],
   external: [

--- a/packages/vite/rollup.config.js
+++ b/packages/vite/rollup.config.js
@@ -7,7 +7,7 @@ export default {
   input: "./vite.js",
   output: [
     { file: pkg.main, format: "cjs", exports: "default" },
-    { file: pkg.exports, format: "es", exports: "default" },
+    { file: pkg.exports.default, format: "es", exports: "default" },
   ],
   plugins: [resolve()],
   external: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -407,7 +407,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nyt/bundler-plugin-gltf@workspace:packages/core":
+"@nyt/bundler-plugin-gltf@workspace:^, @nyt/bundler-plugin-gltf@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@nyt/bundler-plugin-gltf@workspace:packages/core"
   dependencies:
@@ -4821,6 +4821,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "rollup-plugin-gltf@workspace:packages/rollup"
   dependencies:
+    "@nyt/bundler-plugin-gltf": "workspace:^"
     "@rollup/pluginutils": ^5.0.4
     draco3dgltf: ^1.5.6
     meshoptimizer: ^0.19.0
@@ -5684,6 +5685,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "vite-plugin-gltf@workspace:packages/vite"
   dependencies:
+    "@nyt/bundler-plugin-gltf": "workspace:^"
     "@rollup/pluginutils": ^5.0.4
     draco3dgltf: ^1.5.6
     meshoptimizer: ^0.19.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,36 +39,36 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gltf-transform/core@npm:^3.6.0":
-  version: 3.6.0
-  resolution: "@gltf-transform/core@npm:3.6.0"
+"@gltf-transform/core@npm:^3.7.0":
+  version: 3.7.0
+  resolution: "@gltf-transform/core@npm:3.7.0"
   dependencies:
     property-graph: ^1.3.1
-  checksum: a3c4460ce14404ae32948d3019157e1e8ef43602b19b664014ddb648811591d8209f998d4cc01e7ae02c4210393c89f359b20f9ca89792b3bb7c45366a8727e1
+  checksum: 2628074678fbf2c3793a384854793f00033638a7ea556e893f37b97ca981f0ed862b2f479e6d60d2a8a0ca94a8fc26f816238cf1c4ba5f180464882376609783
   languageName: node
   linkType: hard
 
-"@gltf-transform/extensions@npm:^3.6.0":
-  version: 3.6.0
-  resolution: "@gltf-transform/extensions@npm:3.6.0"
+"@gltf-transform/extensions@npm:^3.7.0":
+  version: 3.7.0
+  resolution: "@gltf-transform/extensions@npm:3.7.0"
   dependencies:
-    "@gltf-transform/core": ^3.6.0
+    "@gltf-transform/core": ^3.7.0
     ktx-parse: ^0.6.0
-  checksum: 50d4922e7c7fd1cf56d56a1fdc2a00c6862073c405aaa39b4a260631d49c827f5059d71d1107055d90d72f7a36dfe598cd255f05da2d77c07814ae17f9f3006a
+  checksum: 950769175ab5d4f3a6069a8034440e6983f154ab759494df258746f3b0ca94e5fe880777ca418a56b5522943a56048e347fbdd76716335a8bdbad5180a43d1a7
   languageName: node
   linkType: hard
 
-"@gltf-transform/functions@npm:^3.6.0":
-  version: 3.6.0
-  resolution: "@gltf-transform/functions@npm:3.6.0"
+"@gltf-transform/functions@npm:^3.7.0":
+  version: 3.7.0
+  resolution: "@gltf-transform/functions@npm:3.7.0"
   dependencies:
-    "@gltf-transform/core": ^3.6.0
-    "@gltf-transform/extensions": ^3.6.0
+    "@gltf-transform/core": ^3.7.0
+    "@gltf-transform/extensions": ^3.7.0
     ktx-parse: ^0.6.0
     ndarray: ^1.0.19
     ndarray-lanczos: ^0.3.0
     ndarray-pixels: ^3.0.4
-  checksum: e589fdb91157755ee236a500d03d68fcdbd1b35f15dd9776e4f159ab930398cbcf8b3351a7ad44c9a1bbd93ad58aa1bb7290dda863a1d334a2a178b5c5d0e301
+  checksum: 69c95ff2a7c6fb300f77712e07bd4a623617a5793084e3d32e3003e03f2233ba7dc65cfa91225a10a5812e26a7601d6beef11af68aa079fd565e6c20b6d963d3
   languageName: node
   linkType: hard
 
@@ -415,9 +415,9 @@ __metadata:
     draco3dgltf: ^1.5.6
     meshoptimizer: ^0.19.0
   peerDependencies:
-    "@gltf-transform/core": 2.x
-    "@gltf-transform/extensions": 2.x
-    "@gltf-transform/functions": 2.x
+    "@gltf-transform/core": 3.x
+    "@gltf-transform/extensions": 3.x
+    "@gltf-transform/functions": 3.x
   languageName: unknown
   linkType: soft
 
@@ -4825,9 +4825,9 @@ __metadata:
     draco3dgltf: ^1.5.6
     meshoptimizer: ^0.19.0
   peerDependencies:
-    "@gltf-transform/core": 2.x
-    "@gltf-transform/extensions": 2.x
-    "@gltf-transform/functions": 2.x
+    "@gltf-transform/core": 3.x
+    "@gltf-transform/extensions": 3.x
+    "@gltf-transform/functions": 3.x
   languageName: unknown
   linkType: soft
 
@@ -4849,9 +4849,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@gltf-transform/core": ^3.6.0
-    "@gltf-transform/extensions": ^3.6.0
-    "@gltf-transform/functions": ^3.6.0
+    "@gltf-transform/core": ^3.7.0
+    "@gltf-transform/extensions": ^3.7.0
+    "@gltf-transform/functions": ^3.7.0
     "@rollup/plugin-node-resolve": ^15.2.1
     lerna: ^7.3.0
     rimraf: ^5.0.1
@@ -5688,9 +5688,9 @@ __metadata:
     draco3dgltf: ^1.5.6
     meshoptimizer: ^0.19.0
   peerDependencies:
-    "@gltf-transform/core": 2.x
-    "@gltf-transform/extensions": 2.x
-    "@gltf-transform/functions": 2.x
+    "@gltf-transform/core": 3.x
+    "@gltf-transform/extensions": 3.x
+    "@gltf-transform/functions": 3.x
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Important change to `package.json` for each package here:

```diff
- "main": "dist/core.cjs",
- "module": "dist/core.js",
+ "main": "./dist/core.cjs",
+ "exports": {
+   "require": "./dist/core.cjs",
+   "default": "./dist/core.js"
+ },
```

`module` is ignored in Node.js contexts where Vite and Rollup run, so the previous ESM build was always ignored in favor of CJS. I'll publish this as a new major version, because adding `exports` is typically considered a breaking change.

Along with updating the peer dependencies, this avoids the [dual-package-hazard](https://nodejs.org/api/packages.html#dual-package-hazard) problem where Vite could load a CJS copy of `@gltf-transform/*` for the plugin, an ESM copy for the user's transform operations, and the two wouldn't interoperate correctly.

*** 

To do:

- [x] fix the prerelease macros so we don't increment the version each time
- [x] test a prerelease